### PR TITLE
Add 0.8 calls

### DIFF
--- a/example.py
+++ b/example.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
 from telephus.protocol import ManagedCassandraClientFactory
 from telephus.client import CassandraClient
-from telephus.cassandra.ttypes import ColumnPath, ColumnParent, Column, SuperColumn
+from telephus.cassandra.ttypes import (ColumnPath, ColumnParent, Column,
+                                       SuperColumn, Compression)
 from twisted.internet import defer
 
 HOST = 'localhost'
@@ -9,6 +10,8 @@ PORT = 9160
 KEYSPACE = 'Keyspace1'
 CF = 'Standard1'
 SCF = 'Super1'
+COUNT_CF = 'Counter1'
+SUPERCOUNT_CF = 'SuperCounter1'
 colname = 'foo'
 scname = 'bar'
 
@@ -16,30 +19,53 @@ scname = 'bar'
 def dostuff(client):
     yield client.insert(key='test', column_family=CF, value='testval', column=colname)
     yield client.insert(key='test', column_family=SCF, value='testval', column=colname, super_column=scname)
+
     res = yield client.get(key='test', column_family=CF, column=colname)
     print 'get', res
+
     res = yield client.get(key='test', column_family=SCF, column=colname, super_column=scname)
     print 'get (super)', res
+
     res = yield client.get_slice(key='test', column_family=CF)
     print 'get_slice', res
+
     res = yield client.multiget(keys=['test', 'test2'], column_family=CF, column=colname)
     print 'multiget', res
+
     res = yield client.multiget_slice(keys=['test', 'test2'], column_family=CF)
     print 'multiget_slice', res
+
     res = yield client.get_count(key='test', column_family=CF)
     print 'get_count', res
+
+    yield client.add(key='test', column_family=COUNT_CF, value=1, column='testcounter')
+    res = yield client.get(key='test', column_family=COUNT_CF, column='testcounter')
+    print 'get counter value', res
+
+    yield client.add(key='test', column_family=SUPERCOUNT_CF, value=1,
+                     column='testcounter', super_column='testsuper')
+    res = yield client.get(key='test', column_family=SUPERCOUNT_CF,
+                           column='testcounter', super_column='testsuper')
+    print 'get super counter value', res
+
+    res = yield client.execute_cql_query("SELECT * FROM %s WHERE KEY = %s" % (CF, 'test'.encode('hex')),
+                                         compression=Compression.NONE)
+    print 'execute_cql_query', res
+
     # batch insert will figure out if you're trying a CF or SCF
     # from the data structure
     res = yield client.batch_insert(key='test', column_family=CF, mapping={colname: 'bar'})
     print "batch_insert", res
     res = yield client.batch_insert(key='test', column_family=SCF, mapping={'foo': {colname: 'bar'}})
     print "batch_insert", res
+
     # with ttypes, you pass a list as you would for raw thrift
     # this way you can set custom timestamps
     cols = [Column(colname, 'bar', 1234), Column('bar', 'baz', 54321)]
     res = yield client.batch_insert(key='test', column_family=CF, mapping=cols)
     print "batch_insert", res
     cols = [SuperColumn(name=colname, columns=cols)]
+
     # of course you don't have to use kwargs if the order is correct
     res = yield client.batch_insert('test', SCF, cols)
     print "batch_insert", res

--- a/test/test_cassandraclient.py
+++ b/test/test_cassandraclient.py
@@ -5,6 +5,7 @@ from telephus.protocol import ManagedCassandraClientFactory, APIMismatch
 from telephus.client import CassandraClient
 from telephus.cassandra import constants
 from telephus.cassandra.ttypes import *
+from telephus.translate import getAPIVersion
 import os
 import zlib
 
@@ -37,6 +38,9 @@ class CassandraClientTest(unittest.TestCase):
             reactor.connectTCP(HOST, PORT, self.cmanager)
         yield self.cmanager.deferred
 
+        remote_ver = yield self.client.describe_version()
+        self.version = getAPIVersion(remote_ver)
+
         self.my_keyspace = KsDef(
             name=KEYSPACE,
             strategy_class='org.apache.cassandra.locator.SimpleStrategy',
@@ -66,6 +70,10 @@ class CassandraClientTest(unittest.TestCase):
                     ],
                     default_validation_class='org.apache.cassandra.db.marshal.BytesType'
                 ),
+            ]
+        )
+        if self.version == constants.CASSANDRA_08:
+            self.my_keyspace.cf_defs.extend([
                 CfDef(
                     keyspace=KEYSPACE,
                     name=COUNTER_CF,
@@ -78,8 +86,8 @@ class CassandraClientTest(unittest.TestCase):
                     column_type='Super',
                     default_validation_class='org.apache.cassandra.db.marshal.CounterColumnType'
                 ),
-            ]
-        )
+            ])
+
         yield self.client.system_add_keyspace(self.my_keyspace)
         yield self.client.set_keyspace(KEYSPACE)
 
@@ -193,6 +201,9 @@ class CassandraClientTest(unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_counter_add(self):
+        if self.version != constants.CASSANDRA_08:
+            raise unittest.SkipTest('Counters are not supported in 0.7')
+
         # test standard column counter
         yield self.client.add('test', COUNTER_CF, 1, column='col')
         res = yield self.client.get('test', COUNTER_CF, column='col')
@@ -213,6 +224,9 @@ class CassandraClientTest(unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_counter_remove(self):
+        if self.version != constants.CASSANDRA_08:
+            raise unittest.SkipTest('Counters are not supported in 0.7')
+
         # test standard column counter
         yield self.client.add('test', COUNTER_CF, 1, column='col')
         res = yield self.client.get('test', COUNTER_CF, column='col')
@@ -235,6 +249,9 @@ class CassandraClientTest(unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_cql(self):
+        if self.version != constants.CASSANDRA_08:
+            raise unittest.SkipTest('CQL is not supported in 0.7')
+
         yield self.client.insert('test', CF, 'testval', column='col1')
         res = yield self.client.get('test', CF, column='col1')
         self.assertEquals(res.column.value, 'testval')


### PR DESCRIPTION
This pull request builds on the previous one that added 0.8 compatibility.

This adds support for counter methods and CQL.
