### PR TITLE
Fix cassandraclient test in master

### DIFF
--- a/test/test_cassandraclient.py
+++ b/test/test_cassandraclient.py
@@ -200,18 +200,42 @@ class CassandraClientTest(unittest.TestCase):
         yield self.sleep(2)
         yield self.assertFailure(self.client.get('test_ttls', CF, column=COLUMN), NotFoundException)
 
+    def compare_keyspaces(self, ks1, ks2):
+        self.assertEqual(ks1.name, ks2.name)
+        self.assertEqual(ks1.strategy_class, ks2.strategy_class)
+        self.assertEqual(ks1.cf_defs, ks2.cf_defs)
+
+        def get_rf(ksdef):
+            rf = ksdef.replication_factor
+            if ksdef.strategy_options and \
+               'replication_factor' in ksdef.strategy_options:
+                rf = int(ksdef.strategy_options['replication_factor'])
+            return rf
+
+        def strat_opts_no_rf(ksdef):
+            if not ksdef.strategy_options:
+                return {}
+            opts = ksdef.strategy_options.copy()
+            if 'replication_factor' in ksdef.strategy_options:
+                del opts['replication_factor']
+            return opts
+
+        self.assertEqual(get_rf(ks1), get_rf(ks2))
+        self.assertEqual(strat_opts_no_rf(ks1), strat_opts_no_rf(ks2))
+
     @defer.inlineCallbacks
     def test_keyspace_manipulation(self):
         ksdef = KsDef(name=T_KEYSPACE, strategy_class='org.apache.cassandra.locator.SimpleStrategy', replication_factor=1, cf_defs=[])
         yield self.client.system_add_keyspace(ksdef)
         ks2 = yield self.client.describe_keyspace(T_KEYSPACE)
-        self.assertEqual(ksdef, ks2)
+        self.compare_keyspaces(ksdef, ks2)
+
         if DO_SYSTEM_RENAMING:
             newname = T_KEYSPACE + '2'
             yield self.client.system_rename_keyspace(T_KEYSPACE, newname)
             ks2 = yield self.client.describe_keyspace(newname)
             ksdef.name = newname
-            self.assertEqual(ksdef, ks2)
+            self.compare_keyspaces(ksdef, ks2)
         yield self.client.system_drop_keyspace(ksdef.name)
         yield self.assertFailure(self.client.describe_keyspace(T_KEYSPACE), NotFoundException)
         if DO_SYSTEM_RENAMING:


### PR DESCRIPTION
This fixes the comparison of KsDefs in test_keyspace_manipulation so that the tests pass against 0.7 and 0.8.

The master branch is what needs this -- unstable should be fine right now.
