### PR TITLE
Remove consistency fix

### DIFF
--- a/telephus/client.py
+++ b/telephus/client.py
@@ -168,7 +168,7 @@ class CassandraClient(object):
         cp = self._getpath(column_family, column, super_column)
         timestamp = timestamp or self._time()
         consistency = consistency or self.consistency
-        req = ManagedThriftRequest('remove', key, cp, timestamp, self.consistency)
+        req = ManagedThriftRequest('remove', key, cp, timestamp, consistency)
         return self.manager.pushRequest(req, retries=retries)
 
     @requirekwargs('key', 'column_family', 'column')
@@ -176,7 +176,7 @@ class CassandraClient(object):
                        consistency=None, retries=None):
         cp = self._getpath(column_family, column, super_column)
         consistency = consistency or self.consistency
-        req = ManagedThriftRequest('remove_counter', key, cp, self.consistency)
+        req = ManagedThriftRequest('remove_counter', key, cp, consistency)
         return self.manager.pushRequest(req, retries=retries)
 
     @requirekwargs('key', 'column_family', 'mapping')


### PR DESCRIPTION
remove() and remove_counter() both were using self.consistency
instead of just 'consistency', which is calculated from the
passed argument and self.consistency.
