### PR TITLE
One line fix for an invalid call to defer.errback in pool.py.

### DIFF
--- a/telephus/pool.py
+++ b/telephus/pool.py
@@ -285,7 +285,7 @@ class CassandraPoolReconnectorFactory(protocol.ClientFactory):
 
     def execute(self, req, keyspace=None):
         if self.my_proto is None:
-            return defer.errback(error.ConnectionClosed(
+            return defer.fail(error.ConnectionClosed(
                                     'Lost connection before %s request could be made'
                                     % (req.method,)))
         method = getattr(self.my_proto.client, req.method, None)


### PR DESCRIPTION
Replaced defer.errback with defer.fail. defer.fail is called in
the defer module, defer.errback is called on Deferred instances,
of which none was available in this case.
