### PR TITLE
Update Thrift interface defintion to 19.35.0 (latest 1.2)

### DIFF
--- a/telephus/cassandra/constants.py
+++ b/telephus/cassandra/constants.py
@@ -7,4 +7,4 @@
 from thrift.Thrift import *
 from ttypes import *
 
-VERSION = "19.30.0"
+VERSION = "19.35.0"

--- a/telephus/client.py
+++ b/telephus/client.py
@@ -208,7 +208,7 @@ class CassandraClient(object):
         return self.manager.pushRequest(req, retries=retries)
 
     @requirekwargs('mutationmap')
-    def batch_mutate(self, mutationmap=None, timestamp=None, consistency=None, retries=None, ttl=None):
+    def batch_mutate(self, mutationmap=None, timestamp=None, consistency=None, retries=None, ttl=None, atomic=False):
         timestamp = timestamp or self._time()
         consistency = consistency or self.consistency
         mutmap = defaultdict(dict)
@@ -226,7 +226,9 @@ class CassandraClient(object):
                     else:
                         muts.append(c)
                 mutmap[key][cf] = muts
-        req = ManagedThriftRequest('batch_mutate', mutmap, consistency)
+
+        method = 'atomic_batch_mutate' if atomic else 'batch_mutate'
+        req = ManagedThriftRequest(method, mutmap, consistency)
         return self.manager.pushRequest(req, retries=retries)
 
     def _mk_cols_or_supers(self, mapping, timestamp, ttl=None, make_deletions=False):

--- a/telephus/client.py
+++ b/telephus/client.py
@@ -284,6 +284,10 @@ class CassandraClient(object):
         req = ManagedThriftRequest('describe_ring', keyspace)
         return self.manager.pushRequest(req, retries=retries)
 
+    def describe_token_map(self, retries=None):
+        req = ManagedThriftRequest('describe_token_map')
+        return self.manager.pushRequest(req, retries=retries)
+
     def describe_splits(self, cfName, start_token, end_token, keys_per_split,
                         retries=None):
         req = ManagedThriftRequest('describe_splits', cfName, start_token,


### PR DESCRIPTION
This adds basic support for describe_token_map() and atomic_batch_mutate().
