### PR TITLE
Added a deferred string formatting option to the logstate method and mod...

### DIFF
--- a/telephus/pool.py
+++ b/telephus/pool.py
@@ -355,7 +355,7 @@ class CassandraPoolReconnectorFactory(protocol.ClientFactory):
         return d
 
     def clear_job(self, x):
-        self.logstate('clear job %s (result %r)' % (self.jobphase, x))
+        self.logstate('clear job %s (result %r)', self.jobphase, x)
         self.jobphase = None
         self.job_d = None
         return x
@@ -444,8 +444,9 @@ class CassandraPoolReconnectorFactory(protocol.ClientFactory):
         if self.jobphase != 'pending_request':
             self.stopFactory()
 
-    def logstate(self, msg):
+    def logstate(self, msg, *args):
         if getattr(self, 'debugging', False):
+            if msg and args: msg = msg % args
             log.msg('CPRF 0x%x (node %s) [%s]: %s'
                     % (id(self), self.node, self.jobphase, msg))
 


### PR DESCRIPTION
When testing with semi-large result sets, we observed prolonged periods of heavy CPU utilization and traced it down to this call in clear_job. Since the string formatting occurs prior to the logstate method call, the object stringification penalty is incurred even when "debugging" is disabled. For large results, the stringification process can add up to several seconds or more.

This optimization lets us defer the costly string formatting until after we determine that "debugging" is enabled. It should result in a nice performance increase for anyone working with large result sets, with no loss of functionality.
